### PR TITLE
change to Hpricot require statement

### DIFF
--- a/lib/craigler.rb
+++ b/lib/craigler.rb
@@ -1,5 +1,5 @@
 require 'open-uri'
-require 'Hpricot'
+require 'hpricot'
 
 require 'craigler/constants'
 require 'craigler/search'


### PR DESCRIPTION
Hi,

I made a small change to the require statement in lib/craigler.rb.  I'm on ubuntu 11.10 and was running into a load error for "Hpricot", so I changed it to "hpricot"

Thanks.
